### PR TITLE
Remove scrollbars from <section> when not overflowing (auto)

### DIFF
--- a/public/stylesheets/layout.css
+++ b/public/stylesheets/layout.css
@@ -2,7 +2,7 @@ h1, h2, h3, h4, strong, b {
   font-weight: 600;
 }
 section, article, nav, aside {
-  overflow: scroll;
+  overflow: auto;
 }
 a {
   color: #666;


### PR DESCRIPTION
Just a small visual change that was bugging me.  This removes the unnecessary scroll bars from the views.
