### PR TITLE
Add CORS support for Implicit/Hybrid flow clients

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'validate_email'
 gem 'fb_graph'
 gem 'rack-oauth2'
 gem 'openid_connect'
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-cors (0.4.0)
     rack-oauth2 (1.0.8)
       activesupport (>= 2.3)
       attr_required (>= 0.0.5)
@@ -158,6 +159,7 @@ DEPENDENCIES
   jquery-rails
   openid_connect
   pg
+  rack-cors
   rack-oauth2
   rack-ssl
   rails (~> 3.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,13 @@ module ConnectOp
     #   end
     # end
     # config.middleware.insert_before ActionDispatch::Cookies, RequestResponseLogger
+
+    # Allow CORS readers from all origins
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi Nov,

I've been working with a sample app using the Implicit and Hybrid flows, and the connect-op.herokuapp.com rails app fails because of CORS restrictions in the browser.

This is just a quick patch that uses the [rack-cors](https://github.com/cyu/rack-cors) gem to enable CORS support on all requests.  Here's an example curl call with the changes:

```
curl -v -H "Origin: https://mydomain.com" http://localhost:3000/.well-known/openid-configuration
> GET /.well-known/openid-configuration HTTP/1.1
> User-Agent: curl/7.35.0
> Host: localhost:3000
> Accept: */*
> Origin: https://mydomain.com
> 
< HTTP/1.1 200 OK 
< Content-Type: application/json; charset=utf-8
< X-Ua-Compatible: IE=Edge
< Etag: "0e38db67025577c69e7289e64527c2ac"
< Cache-Control: max-age=0, private, must-revalidate
< X-Request-Id: d1448459891cb61a54c3451731d9334a
< X-Runtime: 0.010562
< Access-Control-Allow-Origin: https://mydomain.com
< Access-Control-Allow-Methods: GET, POST, OPTIONS
< Access-Control-Expose-Headers: 
< Access-Control-Max-Age: 1728000
< Access-Control-Allow-Credentials: true
< Vary: Origin
< Server: WEBrick/1.3.1 (Ruby/2.0.0/2015-04-13)
< Date: Thu, 11 Jun 2015 15:13:35 GMT
< Content-Length: 878
< Connection: Keep-Alive
< 
{"issuer":"http://op.dev","jwks_uri":"http://op.dev/jwks.json",
"response_types_supported":
["code","token","id_token","code token","code id_token","id_token token","code id_token token"],
"subject_types_supported":["public","pairwise"],
"id_token_signing_alg_values_supported":["RS256"],
"authorization_endpoint":"http://localhost:3000/authorizations/new",
"token_endpoint":"http://localhost:3000/access_tokens",
"userinfo_endpoint":"http://localhost:3000/user_info",
"registration_endpoint":"http://localhost:3001/connect/client",
"scopes_supported":["openid","profile","email","address","phone"],
"grant_types_supported":["authorization_code","implicit"],
"request_object_signing_alg_values_supported":["HS256","HS384","HS512"],
"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],
"claims_supported":["sub","iss","name","email","address","phone_number"]}
```