### PR TITLE
support erb in issuer.yml

### DIFF
--- a/app/models/id_token.rb
+++ b/app/models/id_token.rb
@@ -72,7 +72,8 @@ class IdToken < ActiveRecord::Base
     def config
       unless @config
         config_path = File.join Rails.root, 'config/connect/id_token'
-        @config = YAML.load_file(File.join(config_path, 'issuer.yml'))[Rails.env].symbolize_keys
+        issuer_path = File.join config_path, 'issuer.yml'
+        @config = YAML.load(ERB.new(File.read(issuer_path)).result)[Rails.env].symbolize_keys
         @config[:jwks_uri] = File.join(@config[:issuer], 'jwks.json')
         private_key = OpenSSL::PKey::RSA.new(
           File.read(File.join(config_path, 'private.key')),


### PR DESCRIPTION
support erb in config/connect/id_token/issuer.yml.

```yml
development: &defaults
  issuer: <%= ENV['ISSUER'] %>
```