### PR TITLE
Ensure invalid scope error is raised when the scope is unknown

### DIFF
--- a/lib/authorization_endpoint.rb
+++ b/lib/authorization_endpoint.rb
@@ -11,7 +11,7 @@ class AuthorizationEndpoint
         req.invalid_request! 'nonce required'
       end
       @scopes = req.scope.inject([]) do |_scopes_, scope|
-        _scopes_ << Scope.find_by_name(scope) or req.invalid_scope! "Unknown scope: #{scope}"
+        _scopes_ << (Scope.find_by_name(scope) or req.invalid_scope! "Unknown scope: #{scope}")
       end
       @request_object = if (@_request_ = req.request).present?
         OpenIDConnect::RequestObject.decode req.request, nil # @client.secret


### PR DESCRIPTION
The operator precedence of "<<" is higher than "or". `_scopes_ << Scope.find_by_name(scope)` will always be executed first and return true. Hence, `req.invalid_scope!` will not be called even if `Scope.find_by_name(scope)` returns nil.

See issue #10